### PR TITLE
fix: improve Windows desktop support

### DIFF
--- a/apps/desktop/src-tauri/src/cli_integration/mod.rs
+++ b/apps/desktop/src-tauri/src/cli_integration/mod.rs
@@ -1,9 +1,10 @@
-#[cfg(any(target_os = "linux", test))]
+#[cfg(any(target_os = "linux", all(test, unix)))]
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 mod linux;
-#[cfg(any(target_os = "macos", test))]
+#[cfg(any(target_os = "macos", all(test, unix)))]
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 mod macos;
+#[cfg(unix)]
 mod unix_link;
 #[cfg(any(target_os = "windows", test))]
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]

--- a/apps/desktop/src-tauri/src/cli_integration/windows.rs
+++ b/apps/desktop/src-tauri/src/cli_integration/windows.rs
@@ -54,7 +54,11 @@ mod platform {
     const MACHINE_ENVIRONMENT: &str =
         r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment";
 
-    pub(super) fn status() -> Result<CliIntegrationStatus, String> {
+    fn os_error(code: u32) -> String {
+        io::Error::from_raw_os_error(code as i32).to_string()
+    }
+
+    pub(crate) fn status() -> Result<CliIntegrationStatus, String> {
         let directory = install_directory()?;
         let cli = directory.join("print-bridge.exe");
         if !cli.is_file() {
@@ -82,7 +86,7 @@ mod platform {
         })
     }
 
-    pub(super) fn install() -> Result<CliIntegrationStatus, String> {
+    pub(crate) fn install() -> Result<CliIntegrationStatus, String> {
         let directory = install_directory()?;
         if !directory.join("print-bridge.exe").is_file() {
             return status();
@@ -94,7 +98,7 @@ mod platform {
         status()
     }
 
-    pub(super) fn uninstall() -> Result<CliIntegrationStatus, String> {
+    pub(crate) fn uninstall() -> Result<CliIntegrationStatus, String> {
         let directory = install_directory()?;
         let entry = directory.display().to_string();
         let (value, kind) = read_path(HKEY_CURRENT_USER, USER_ENVIRONMENT, true)?;
@@ -121,7 +125,7 @@ mod platform {
             let access = KEY_READ | if writable { KEY_SET_VALUE } else { 0 };
             let code = RegOpenKeyExW(root, wide(subkey).as_ptr(), 0, access, &mut key);
             if code != ERROR_SUCCESS {
-                return Err(io::Error::from_raw_os_error(code).to_string());
+                return Err(os_error(code));
             }
             let name = wide("Path");
             let mut kind = REG_EXPAND_SZ;
@@ -140,7 +144,7 @@ mod platform {
             }
             if code != ERROR_SUCCESS {
                 RegCloseKey(key);
-                return Err(io::Error::from_raw_os_error(code).to_string());
+                return Err(os_error(code));
             }
             let mut buffer = vec![0u16; length as usize / 2];
             let code = RegQueryValueExW(
@@ -153,7 +157,7 @@ mod platform {
             );
             RegCloseKey(key);
             if code != ERROR_SUCCESS {
-                return Err(io::Error::from_raw_os_error(code).to_string());
+                return Err(os_error(code));
             }
             while buffer.last() == Some(&0) {
                 buffer.pop();
@@ -173,7 +177,7 @@ mod platform {
                 &mut key,
             );
             if code != ERROR_SUCCESS {
-                return Err(io::Error::from_raw_os_error(code).to_string());
+                return Err(os_error(code));
             }
             let encoded = wide(value);
             let value_kind = if kind == REG_SZ {
@@ -193,7 +197,7 @@ mod platform {
             if code == ERROR_SUCCESS {
                 Ok(())
             } else {
-                Err(io::Error::from_raw_os_error(code).to_string())
+                Err(os_error(code))
             }
         }
     }
@@ -216,7 +220,7 @@ mod platform {
 }
 
 #[cfg(target_os = "windows")]
-pub(super) use platform::{install, status, uninstall};
+pub(crate) use platform::{install, status, uninstall};
 
 #[cfg(test)]
 mod tests {

--- a/apps/desktop/src-tauri/src/cli_integration/windows.rs
+++ b/apps/desktop/src-tauri/src/cli_integration/windows.rs
@@ -54,6 +54,7 @@ mod platform {
     const MACHINE_ENVIRONMENT: &str =
         r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment";
 
+    /// 将 Win32 错误码转换为可显示的系统错误信息。
     fn os_error(code: u32) -> String {
         io::Error::from_raw_os_error(code as i32).to_string()
     }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -72,21 +72,34 @@ pub async fn save_config(
     state: State<'_, AgentState>,
     service: State<'_, Arc<CommandService>>,
 ) -> Result<AgentConfig, CommandError> {
-    let current_port = state.config.read().await.service.port;
+    let current = state.config.read().await.clone();
+    let current_port = current.service.port;
     if config.service.port != current_port {
         check_service_port_available_for_host("0.0.0.0", config.service.port).map_err(
             |message| CommandError::new(print_bridge_cli::CommandErrorKind::InvalidInput, message),
         )?;
     }
 
-    let saved = match service.execute(Command::SaveConfig(config)).await? {
-        CommandResult::Config(config) => *config,
-        _ => unreachable!("SaveConfig returned an unexpected result"),
+    apply_autostart(&app, config.app.autostart).map_err(|message| {
+        CommandError::new(print_bridge_cli::CommandErrorKind::Runtime, message)
+    })?;
+
+    let saved = match service.execute(Command::SaveConfig(config)).await {
+        Ok(CommandResult::Config(config)) => *config,
+        Ok(_) => unreachable!("SaveConfig returned an unexpected result"),
+        Err(error) => {
+            if let Err(rollback_error) = apply_autostart(&app, current.app.autostart) {
+                return Err(CommandError::new(
+                    print_bridge_cli::CommandErrorKind::Runtime,
+                    format!(
+                        "{error}; failed to restore the previous autostart setting: {rollback_error}"
+                    ),
+                ));
+            }
+            return Err(error);
+        }
     };
 
-    if let Err(error) = apply_autostart(&app, saved.app.autostart) {
-        tauri_plugin_log::log::warn!("failed to sync autostart after save: {error}");
-    }
     if let Err(error) = apply_tray_language(&app, saved.app.language) {
         tauri_plugin_log::log::warn!("failed to sync tray language after save: {error}");
     }
@@ -179,6 +192,10 @@ pub(crate) async fn save_config_for_state(
 /// 通过 Tauri 自启动插件启用或禁用系统开机自启。
 fn apply_autostart(app: &tauri::AppHandle, enabled: bool) -> Result<(), String> {
     let autolaunch = app.autolaunch();
+    let is_enabled = autolaunch.is_enabled().map_err(|error| error.to_string())?;
+    if enabled == is_enabled {
+        return Ok(());
+    }
     if enabled {
         autolaunch.enable()
     } else {

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -79,19 +79,17 @@ pub async fn save_config(
         )?;
     }
 
-    apply_autostart(&app, config.app.autostart).map_err(|message| {
-        CommandError::new(print_bridge_cli::CommandErrorKind::Runtime, message)
-    })?;
     let saved = match service.execute(Command::SaveConfig(config)).await? {
         CommandResult::Config(config) => *config,
         _ => unreachable!("SaveConfig returned an unexpected result"),
     };
-    apply_tray_language(&app, saved.app.language).map_err(|error| {
-        CommandError::new(
-            print_bridge_cli::CommandErrorKind::Runtime,
-            error.to_string(),
-        )
-    })?;
+
+    if let Err(error) = apply_autostart(&app, saved.app.autostart) {
+        tauri_plugin_log::log::warn!("failed to sync autostart after save: {error}");
+    }
+    if let Err(error) = apply_tray_language(&app, saved.app.language) {
+        tauri_plugin_log::log::warn!("failed to sync tray language after save: {error}");
+    }
 
     Ok(saved)
 }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import tailwindcss from '@tailwindcss/vite';
+import { fileURLToPath } from 'node:url';
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
@@ -10,7 +11,7 @@ export default defineConfig(async () => ({
   plugins: [vue(), tailwindcss()],
   resolve: {
     alias: {
-      '@': new URL('./src', import.meta.url).pathname,
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -38,7 +38,7 @@ zip = "4.6.1"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.61"
-features = ["Win32_Foundation", "Win32_Graphics_Printing"]
+features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_Graphics_Printing"]
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/runtime/src/doctor.rs
+++ b/crates/runtime/src/doctor.rs
@@ -9,7 +9,7 @@ use print_bridge_cli::{DoctorCheck, DoctorReport, DoctorStatus, ProductKind};
 use crate::{
     config::AgentConfig,
     html::{
-        browser::{BrowserExecutable, BrowserLocator},
+        browser::{check_browser_launch, BrowserExecutable},
         HtmlRenderError,
     },
     state::AgentState,
@@ -28,7 +28,7 @@ pub async fn run_doctor(
         agent_check(listen_addr),
         port_check(&config, listen_addr),
         printer_check(state),
-        browser_check(BrowserLocator::new().find()),
+        browser_check(check_browser_launch()),
         executable_check("office.available", office_candidates(), office_suggestion()),
     ];
     if product == ProductKind::Headless {

--- a/crates/runtime/src/html/browser.rs
+++ b/crates/runtime/src/html/browser.rs
@@ -60,7 +60,7 @@ impl BrowserKind {
     }
 }
 
-/// 已通过版本探测的浏览器可执行文件。
+/// 可用于启动渲染器的浏览器可执行文件。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserExecutable {
     pub kind: BrowserKind,
@@ -160,7 +160,7 @@ impl BrowserLocator {
         Self { os, probe }
     }
 
-    /// 返回优先级最高、并能成功返回版本号的浏览器。
+    /// 返回当前平台优先级最高且可用的浏览器。
     pub fn find(&self) -> Result<BrowserExecutable, HtmlRenderError> {
         let candidates = self.candidates();
         let searched = candidates
@@ -168,9 +168,13 @@ impl BrowserLocator {
             .map(|(_, candidate)| candidate.display().to_string())
             .collect::<Vec<_>>();
         for (kind, path) in candidates {
-            if (self.os == TargetOs::Linux || self.probe.is_file(&path))
-                && self.probe.has_version(&path)
-            {
+            // Windows 和 macOS 不再仅为查询版本启动浏览器，避免激活用户已有窗口。
+            // 后续实际的 headless 启动才是最终可用性检查。
+            let available = match self.os {
+                TargetOs::Windows | TargetOs::MacOs => self.probe.is_file(&path),
+                TargetOs::Linux => self.probe.has_version(&path),
+            };
+            if available {
                 return Ok(BrowserExecutable {
                     kind,
                     path,

--- a/crates/runtime/src/html/browser.rs
+++ b/crates/runtime/src/html/browser.rs
@@ -14,7 +14,8 @@ use std::{
     process::{Command, Stdio},
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc,
+        mpsc::{self, RecvTimeoutError},
+        Arc, Condvar, Mutex,
     },
     thread,
     time::{Duration, Instant},
@@ -26,6 +27,7 @@ const RENDER_TIMEOUT: Duration = Duration::from_secs(60);
 const MAX_CDP_OPERATION_TIMEOUT: Duration = Duration::from_secs(10);
 const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const FORCE_LOOPBACK_THROUGH_PROXY: &str = "--proxy-bypass-list=<-loopback>";
+static BROWSER_LAUNCH_GATE: (Mutex<bool>, Condvar) = (Mutex::new(false), Condvar::new());
 
 fn chrome_proxy_server(proxy_url: &Url) -> String {
     let host = proxy_url
@@ -170,6 +172,7 @@ impl BrowserLocator {
             .expect("available browser candidates must not be empty"))
     }
 
+    /// 返回按平台优先级排序的全部可用浏览器。
     fn available(&self) -> Result<Vec<BrowserExecutable>, Vec<String>> {
         let candidates = self.candidates();
         let searched = candidates
@@ -290,7 +293,7 @@ fn linux_candidates(probe: &dyn BrowserProbe) -> Vec<(BrowserKind, PathBuf)> {
 pub struct BrowserDriverRequest {
     proxy_url: Url,
     target_url: Url,
-    profile_path: PathBuf,
+    profile: Arc<tempfile::TempDir>,
     paper: EffectivePaper,
     wait_ms: u64,
     print_background: bool,
@@ -396,56 +399,147 @@ struct InstalledBrowserDriver {
     locator: BrowserLocator,
 }
 
+#[derive(Debug)]
+enum BrowserLaunchAttemptError {
+    Failed(String),
+    TimedOut { timeout_ms: u64 },
+    Abort(HtmlRenderError),
+}
+
+struct BrowserLaunchGuard;
+
+impl BrowserLaunchGuard {
+    /// 在 deadline 前获取全局浏览器启动权，防止累积后台进程。
+    fn acquire(deadline: Instant, timeout_ms: u64) -> Result<Self, BrowserLaunchAttemptError> {
+        let (mutex, condvar) = &BROWSER_LAUNCH_GATE;
+        let mut in_progress = mutex.lock().unwrap_or_else(|error| error.into_inner());
+        while *in_progress {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(BrowserLaunchAttemptError::TimedOut { timeout_ms });
+            }
+            let (next, wait) = condvar
+                .wait_timeout(in_progress, remaining)
+                .unwrap_or_else(|error| error.into_inner());
+            in_progress = next;
+            if wait.timed_out() && *in_progress {
+                return Err(BrowserLaunchAttemptError::TimedOut { timeout_ms });
+            }
+        }
+        *in_progress = true;
+        Ok(Self)
+    }
+}
+
+impl Drop for BrowserLaunchGuard {
+    fn drop(&mut self) {
+        let (mutex, condvar) = &BROWSER_LAUNCH_GATE;
+        let mut in_progress = mutex.lock().unwrap_or_else(|error| error.into_inner());
+        *in_progress = false;
+        condvar.notify_one();
+    }
+}
+
+/// 在独立线程中启动浏览器，并限制调用方等待启动结果的时间。
+fn launch_with_timeout<T: Send + 'static>(
+    timeout: Duration,
+    timeout_ms: u64,
+    launch: impl FnOnce() -> Result<T, String> + Send + 'static,
+) -> Result<T, BrowserLaunchAttemptError> {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .unwrap_or_else(Instant::now);
+    let guard = BrowserLaunchGuard::acquire(deadline, timeout_ms)?;
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        return Err(BrowserLaunchAttemptError::TimedOut { timeout_ms });
+    }
+    let (sender, receiver) = mpsc::sync_channel(1);
+    thread::Builder::new()
+        .name("browser-launch".to_owned())
+        .spawn(move || {
+            let _guard = guard;
+            let _ = sender.send(launch());
+        })
+        .map_err(|error| BrowserLaunchAttemptError::Failed(error.to_string()))?;
+
+    match receiver.recv_timeout(remaining) {
+        Ok(Ok(browser)) => Ok(browser),
+        Ok(Err(error)) => Err(BrowserLaunchAttemptError::Failed(error)),
+        Err(RecvTimeoutError::Timeout) => Err(BrowserLaunchAttemptError::TimedOut { timeout_ms }),
+        Err(RecvTimeoutError::Disconnected) => Err(BrowserLaunchAttemptError::Failed(
+            "browser launch worker stopped unexpectedly".to_owned(),
+        )),
+    }
+}
+
 /// 依次启动已发现的浏览器，直到一个浏览器可用于 headless 渲染。
 fn launch_first_available<T>(
     candidates: Vec<BrowserExecutable>,
-    mut launch: impl FnMut(&BrowserExecutable) -> Result<T, String>,
+    mut launch: impl FnMut(BrowserExecutable) -> Result<T, BrowserLaunchAttemptError>,
 ) -> Result<(T, BrowserExecutable), HtmlRenderError> {
     let mut failures = Vec::new();
     for executable in candidates {
-        match launch(&executable) {
+        match launch(executable.clone()) {
             Ok(browser) => return Ok((browser, executable)),
-            Err(error) => failures.push(format!("{}: {error}", executable.path.display())),
+            Err(BrowserLaunchAttemptError::Failed(error)) => {
+                failures.push(format!("{}: {error}", executable.path.display()));
+            }
+            Err(BrowserLaunchAttemptError::TimedOut { timeout_ms }) => {
+                return Err(HtmlRenderError::Timeout { timeout_ms });
+            }
+            Err(BrowserLaunchAttemptError::Abort(error)) => return Err(error),
         }
     }
     Err(HtmlRenderError::RendererUnavailable { searched: failures })
 }
 
+/// 按优先级启动浏览器，并在每次尝试前获取剩余启动超时。
 fn launch_headless_browser(
     locator: &BrowserLocator,
-    profile_path: &Path,
+    profile: Arc<tempfile::TempDir>,
     proxy_server: Option<&str>,
-    idle_browser_timeout: Duration,
+    mut attempt_timeout: impl FnMut() -> Result<(Duration, u64), HtmlRenderError>,
 ) -> Result<(Browser, BrowserExecutable), HtmlRenderError> {
     let candidates = locator
         .available()
         .map_err(|searched| HtmlRenderError::RendererUnavailable { searched })?;
     let proxy_server = proxy_server.map(str::to_owned);
     launch_first_available(candidates, |executable| {
-        let options = LaunchOptionsBuilder::default()
-            .path(Some(executable.path.clone()))
-            .user_data_dir(Some(profile_path.to_path_buf()))
-            .proxy_server(proxy_server.as_deref())
-            .args(vec![std::ffi::OsStr::new(FORCE_LOOPBACK_THROUGH_PROXY)])
-            .ignore_certificate_errors(false)
-            .headless(true)
-            .sandbox(true)
-            .idle_browser_timeout(idle_browser_timeout)
-            .build()
-            .map_err(|error| error.to_string())?;
-        Browser::new(options).map_err(|error| error.to_string())
+        let (timeout, timeout_ms) = attempt_timeout().map_err(BrowserLaunchAttemptError::Abort)?;
+        let profile = profile.clone();
+        let proxy_server = proxy_server.clone();
+        launch_with_timeout(timeout, timeout_ms, move || {
+            let options = LaunchOptionsBuilder::default()
+                .path(Some(executable.path))
+                .user_data_dir(Some(profile.path().to_path_buf()))
+                .proxy_server(proxy_server.as_deref())
+                .args(vec![std::ffi::OsStr::new(FORCE_LOOPBACK_THROUGH_PROXY)])
+                .ignore_certificate_errors(false)
+                .headless(true)
+                .sandbox(true)
+                .idle_browser_timeout(timeout.min(MAX_CDP_OPERATION_TIMEOUT))
+                .build()
+                .map_err(|error| error.to_string())?;
+            Browser::new(options).map_err(|error| error.to_string())
+        })
     })
 }
 
 /// 检查是否有已安装的浏览器可以以 headless 模式启动。
 pub fn check_browser_launch() -> Result<BrowserExecutable, HtmlRenderError> {
-    let profile = tempfile::tempdir()?;
-    let (_, executable) = launch_headless_browser(
-        &BrowserLocator::new(),
-        profile.path(),
-        None,
-        MAX_CDP_OPERATION_TIMEOUT,
-    )?;
+    let profile = Arc::new(tempfile::tempdir()?);
+    let deadline = Instant::now() + RENDER_TIMEOUT;
+    let (_, executable) = launch_headless_browser(&BrowserLocator::new(), profile, None, || {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            Err(HtmlRenderError::Timeout {
+                timeout_ms: RENDER_TIMEOUT.as_millis() as u64,
+            })
+        } else {
+            Ok((remaining, RENDER_TIMEOUT.as_millis() as u64))
+        }
+    })?;
     Ok(executable)
 }
 
@@ -463,13 +557,13 @@ impl BrowserDriver for InstalledBrowserDriver {
         request: BrowserDriverRequest,
         control: BrowserRenderControl,
     ) -> Result<(), HtmlRenderError> {
-        let cdp_operation_timeout = control.before_cdp_operations(1)?;
+        let cdp_operation_timeout = control.cdp_operation_timeout;
         let proxy_server = chrome_proxy_server(&request.proxy_url);
         let (browser, _) = launch_headless_browser(
             &self.locator,
-            &request.profile_path,
+            request.profile.clone(),
             Some(&proxy_server),
-            cdp_operation_timeout,
+            || Ok((control.remaining()?, control.timeout_ms)),
         )?;
         control.before_cdp_operations(1)?;
         let new_tab_wait_timeout = control.remaining()?.saturating_sub(cdp_operation_timeout);
@@ -556,11 +650,11 @@ impl HtmlRenderer for BrowserHtmlRenderer {
             let mut proxy = FilteringProxy::start(policy, inline_html).await?;
             let target_url = proxy.target_url(request.source.clone());
             let rejected_resources = proxy.rejection_tracker();
-            let profile = tempfile::tempdir()?;
+            let profile = Arc::new(tempfile::tempdir()?);
             let driver_request = BrowserDriverRequest {
                 proxy_url: proxy.proxy_url().clone(),
                 target_url,
-                profile_path: profile.path().to_path_buf(),
+                profile: profile.clone(),
                 paper: request.paper,
                 wait_ms: request.wait_ms,
                 print_background: true,
@@ -592,7 +686,6 @@ impl HtmlRenderer for BrowserHtmlRenderer {
                 return Err(HtmlRenderError::BlockedResource { resource });
             }
             control.check_active()?;
-            drop(profile);
             Ok(HtmlRenderResult {
                 renderer: "chromium",
                 output_path: request.output_path,
@@ -754,7 +847,9 @@ mod tests {
         let (_, executable) = super::launch_first_available(vec![edge, chrome], |candidate| {
             attempted.push(candidate.kind);
             if candidate.kind == BrowserKind::Edge {
-                Err("blocked by policy".to_owned())
+                Err(super::BrowserLaunchAttemptError::Failed(
+                    "blocked by policy".to_owned(),
+                ))
             } else {
                 Ok(())
             }
@@ -763,6 +858,58 @@ mod tests {
 
         assert_eq!(attempted, vec![BrowserKind::Edge, BrowserKind::Chrome]);
         assert_eq!(executable.kind, BrowserKind::Chrome);
+    }
+
+    #[test]
+    fn browser_launch_timeout_stops_fallback_before_the_next_candidate() {
+        let edge = BrowserExecutable {
+            kind: BrowserKind::Edge,
+            path: PathBuf::from("edge.exe"),
+            label: "edge",
+        };
+        let chrome = BrowserExecutable {
+            kind: BrowserKind::Chrome,
+            path: PathBuf::from("chrome.exe"),
+            label: "chrome",
+        };
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_for_launch = attempts.clone();
+
+        let result = super::launch_first_available(vec![edge, chrome], move |_| {
+            attempts_for_launch.fetch_add(1, Ordering::AcqRel);
+            super::launch_with_timeout(Duration::from_millis(5), 5, || {
+                thread::sleep(Duration::from_millis(50));
+                Ok::<(), String>(())
+            })
+        });
+
+        assert!(matches!(
+            result,
+            Err(crate::html::HtmlRenderError::Timeout { timeout_ms: 5 })
+        ));
+        assert_eq!(attempts.load(Ordering::Acquire), 1);
+
+        let short_launch_started = Arc::new(AtomicBool::new(false));
+        let started_with_short_budget = short_launch_started.clone();
+        let overlapping_result =
+            super::launch_with_timeout(Duration::from_millis(5), 5, move || {
+                started_with_short_budget.store(true, Ordering::Release);
+                Ok::<(), String>(())
+            });
+        assert!(matches!(
+            overlapping_result,
+            Err(super::BrowserLaunchAttemptError::TimedOut { timeout_ms: 5 })
+        ));
+        assert!(!short_launch_started.load(Ordering::Acquire));
+
+        let waiting_launch_started = Arc::new(AtomicBool::new(false));
+        let started_after_waiting = waiting_launch_started.clone();
+        super::launch_with_timeout(Duration::from_secs(1), 1_000, move || {
+            started_after_waiting.store(true, Ordering::Release);
+            Ok::<(), String>(())
+        })
+        .unwrap();
+        assert!(waiting_launch_started.load(Ordering::Acquire));
     }
 
     #[test]
@@ -784,7 +931,7 @@ mod tests {
             request: BrowserDriverRequest,
             _control: super::BrowserRenderControl,
         ) -> Result<(), crate::html::HtmlRenderError> {
-            assert!(request.profile_path.is_dir());
+            assert!(request.profile.path().is_dir());
             self.requests.lock().unwrap().push(request);
             Ok(())
         }
@@ -824,8 +971,8 @@ mod tests {
             control: super::BrowserRenderControl,
         ) -> Result<(), crate::html::HtmlRenderError> {
             self.saw_profile
-                .store(request.profile_path.is_dir(), Ordering::Release);
-            *self.profile_path.lock().unwrap() = Some(request.profile_path.clone());
+                .store(request.profile.path().is_dir(), Ordering::Release);
+            *self.profile_path.lock().unwrap() = Some(request.profile.path().to_path_buf());
             *self.proxy_url.lock().unwrap() = Some(request.proxy_url);
             while !control.cancelled.load(Ordering::Acquire) {
                 thread::sleep(Duration::from_millis(1));

--- a/crates/runtime/src/html/browser.rs
+++ b/crates/runtime/src/html/browser.rs
@@ -60,7 +60,7 @@ impl BrowserKind {
     }
 }
 
-/// 可用于启动渲染器的浏览器可执行文件。
+/// 已发现的浏览器可执行文件。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserExecutable {
     pub kind: BrowserKind,
@@ -162,27 +162,41 @@ impl BrowserLocator {
 
     /// 返回当前平台优先级最高且可用的浏览器。
     pub fn find(&self) -> Result<BrowserExecutable, HtmlRenderError> {
+        Ok(self
+            .available()
+            .map_err(|searched| HtmlRenderError::RendererUnavailable { searched })?
+            .into_iter()
+            .next()
+            .expect("available browser candidates must not be empty"))
+    }
+
+    fn available(&self) -> Result<Vec<BrowserExecutable>, Vec<String>> {
         let candidates = self.candidates();
         let searched = candidates
             .iter()
             .map(|(_, candidate)| candidate.display().to_string())
             .collect::<Vec<_>>();
+        let mut available_candidates = Vec::new();
         for (kind, path) in candidates {
-            // Windows 和 macOS 不再仅为查询版本启动浏览器，避免激活用户已有窗口。
-            // 后续实际的 headless 启动才是最终可用性检查。
-            let available = match self.os {
-                TargetOs::Windows | TargetOs::MacOs => self.probe.is_file(&path),
+            let is_available = match self.os {
+                // Windows 不运行 `--version`，避免激活用户已有的浏览器窗口。
+                TargetOs::Windows => self.probe.is_file(&path),
+                TargetOs::MacOs => self.probe.is_file(&path) && self.probe.has_version(&path),
                 TargetOs::Linux => self.probe.has_version(&path),
             };
-            if available {
-                return Ok(BrowserExecutable {
+            if is_available {
+                available_candidates.push(BrowserExecutable {
                     kind,
                     path,
                     label: kind.label(),
                 });
             }
         }
-        Err(HtmlRenderError::RendererUnavailable { searched })
+        if available_candidates.is_empty() {
+            Err(searched)
+        } else {
+            Ok(available_candidates)
+        }
     }
 
     fn candidates(&self) -> Vec<(BrowserKind, PathBuf)> {
@@ -382,6 +396,59 @@ struct InstalledBrowserDriver {
     locator: BrowserLocator,
 }
 
+/// 依次启动已发现的浏览器，直到一个浏览器可用于 headless 渲染。
+fn launch_first_available<T>(
+    candidates: Vec<BrowserExecutable>,
+    mut launch: impl FnMut(&BrowserExecutable) -> Result<T, String>,
+) -> Result<(T, BrowserExecutable), HtmlRenderError> {
+    let mut failures = Vec::new();
+    for executable in candidates {
+        match launch(&executable) {
+            Ok(browser) => return Ok((browser, executable)),
+            Err(error) => failures.push(format!("{}: {error}", executable.path.display())),
+        }
+    }
+    Err(HtmlRenderError::RendererUnavailable { searched: failures })
+}
+
+fn launch_headless_browser(
+    locator: &BrowserLocator,
+    profile_path: &Path,
+    proxy_server: Option<&str>,
+    idle_browser_timeout: Duration,
+) -> Result<(Browser, BrowserExecutable), HtmlRenderError> {
+    let candidates = locator
+        .available()
+        .map_err(|searched| HtmlRenderError::RendererUnavailable { searched })?;
+    let proxy_server = proxy_server.map(str::to_owned);
+    launch_first_available(candidates, |executable| {
+        let options = LaunchOptionsBuilder::default()
+            .path(Some(executable.path.clone()))
+            .user_data_dir(Some(profile_path.to_path_buf()))
+            .proxy_server(proxy_server.as_deref())
+            .args(vec![std::ffi::OsStr::new(FORCE_LOOPBACK_THROUGH_PROXY)])
+            .ignore_certificate_errors(false)
+            .headless(true)
+            .sandbox(true)
+            .idle_browser_timeout(idle_browser_timeout)
+            .build()
+            .map_err(|error| error.to_string())?;
+        Browser::new(options).map_err(|error| error.to_string())
+    })
+}
+
+/// 检查是否有已安装的浏览器可以以 headless 模式启动。
+pub fn check_browser_launch() -> Result<BrowserExecutable, HtmlRenderError> {
+    let profile = tempfile::tempdir()?;
+    let (_, executable) = launch_headless_browser(
+        &BrowserLocator::new(),
+        profile.path(),
+        None,
+        MAX_CDP_OPERATION_TIMEOUT,
+    )?;
+    Ok(executable)
+}
+
 impl InstalledBrowserDriver {
     fn new() -> Self {
         Self {
@@ -396,24 +463,14 @@ impl BrowserDriver for InstalledBrowserDriver {
         request: BrowserDriverRequest,
         control: BrowserRenderControl,
     ) -> Result<(), HtmlRenderError> {
-        let executable = self.locator.find()?;
         let cdp_operation_timeout = control.before_cdp_operations(1)?;
         let proxy_server = chrome_proxy_server(&request.proxy_url);
-        let options = LaunchOptionsBuilder::default()
-            .path(Some(executable.path.clone()))
-            .user_data_dir(Some(request.profile_path.clone()))
-            .proxy_server(Some(&proxy_server))
-            .args(vec![std::ffi::OsStr::new(FORCE_LOOPBACK_THROUGH_PROXY)])
-            .ignore_certificate_errors(false)
-            .headless(true)
-            .sandbox(true)
-            .idle_browser_timeout(cdp_operation_timeout)
-            .build()
-            .map_err(HtmlRenderError::browser_options)?;
-        let browser =
-            Browser::new(options).map_err(|error| HtmlRenderError::RendererUnavailable {
-                searched: vec![executable.path.display().to_string(), error.to_string()],
-            })?;
+        let (browser, _) = launch_headless_browser(
+            &self.locator,
+            &request.profile_path,
+            Some(&proxy_server),
+            cdp_operation_timeout,
+        )?;
         control.before_cdp_operations(1)?;
         let new_tab_wait_timeout = control.remaining()?.saturating_sub(cdp_operation_timeout);
         browser.set_default_timeout(new_tab_wait_timeout);
@@ -545,12 +602,6 @@ impl HtmlRenderer for BrowserHtmlRenderer {
 }
 
 impl HtmlRenderError {
-    fn browser_options(error: impl std::fmt::Display) -> Self {
-        Self::Navigation {
-            message: format!("browser launch options are invalid: {error}"),
-        }
-    }
-
     fn navigation(error: impl std::fmt::Display) -> Self {
         Self::Navigation {
             message: error.to_string(),
@@ -567,8 +618,8 @@ impl HtmlRenderError {
 #[cfg(test)]
 mod tests {
     use super::{
-        BrowserDriver, BrowserDriverRequest, BrowserHtmlRenderer, BrowserKind, BrowserLocator,
-        BrowserProbe, TargetOs,
+        BrowserDriver, BrowserDriverRequest, BrowserExecutable, BrowserHtmlRenderer, BrowserKind,
+        BrowserLocator, BrowserProbe, TargetOs,
     };
     use crate::{
         html::{resource_policy::ResourcePolicy, HtmlRenderRequest, HtmlRenderer, HtmlSource},
@@ -592,6 +643,7 @@ mod tests {
     struct FakeProbe {
         files: Vec<PathBuf>,
         commands: HashMap<String, PathBuf>,
+        version_paths: Option<Vec<PathBuf>>,
     }
 
     impl BrowserProbe for FakeProbe {
@@ -603,8 +655,11 @@ mod tests {
             self.commands.get(command).cloned()
         }
 
-        fn has_version(&self, _path: &Path) -> bool {
-            true
+        fn has_version(&self, path: &Path) -> bool {
+            self.version_paths
+                .as_ref()
+                .map(|paths| paths.iter().any(|candidate| candidate == path))
+                .unwrap_or(true)
         }
     }
 
@@ -664,6 +719,50 @@ mod tests {
             fake_path_probe(["google-chrome-stable", "chromium"]),
         );
         assert_eq!(linux.find().unwrap().kind, BrowserKind::Chrome);
+    }
+
+    #[test]
+    fn macos_skips_browsers_that_fail_the_version_probe() {
+        let chrome = PathBuf::from("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome");
+        let chromium = PathBuf::from("/Applications/Chromium.app/Contents/MacOS/Chromium");
+        let locator = BrowserLocator::for_test(
+            TargetOs::MacOs,
+            Arc::new(FakeProbe {
+                files: vec![chrome, chromium.clone()],
+                version_paths: Some(vec![chromium]),
+                ..Default::default()
+            }),
+        );
+
+        assert_eq!(locator.find().unwrap().kind, BrowserKind::Chromium);
+    }
+
+    #[test]
+    fn browser_launch_falls_back_to_the_next_available_candidate() {
+        let edge = BrowserExecutable {
+            kind: BrowserKind::Edge,
+            path: PathBuf::from("C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe"),
+            label: "edge",
+        };
+        let chrome = BrowserExecutable {
+            kind: BrowserKind::Chrome,
+            path: PathBuf::from("C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"),
+            label: "chrome",
+        };
+        let mut attempted = Vec::new();
+
+        let (_, executable) = super::launch_first_available(vec![edge, chrome], |candidate| {
+            attempted.push(candidate.kind);
+            if candidate.kind == BrowserKind::Edge {
+                Err("blocked by policy".to_owned())
+            } else {
+                Ok(())
+            }
+        })
+        .unwrap();
+
+        assert_eq!(attempted, vec![BrowserKind::Edge, BrowserKind::Chrome]);
+        assert_eq!(executable.kind, BrowserKind::Chrome);
     }
 
     #[test]

--- a/crates/runtime/src/html/browser.rs
+++ b/crates/runtime/src/html/browser.rs
@@ -1126,14 +1126,12 @@ mod tests {
         assert!(!output_path.exists());
         let proxy_url = driver.proxy_url.lock().unwrap().clone().unwrap();
         let proxy_port = proxy_url.port().unwrap();
-        assert!(matches!(
-            tokio::time::timeout(
-                Duration::from_millis(100),
-                tokio::net::TcpStream::connect(("127.0.0.1", proxy_port)),
-            )
-            .await,
-            Ok(Err(_))
-        ));
+        let connection = tokio::time::timeout(
+            Duration::from_millis(100),
+            tokio::net::TcpStream::connect(("127.0.0.1", proxy_port)),
+        )
+        .await;
+        assert!(!matches!(connection, Ok(Ok(_))));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/printing/windows.rs
+++ b/crates/runtime/src/printing/windows.rs
@@ -204,7 +204,7 @@ struct PowerShellPrinter {
     #[serde(rename = "Name")]
     name: String,
     #[serde(rename = "Default", default)]
-    default: bool,
+    default: Option<bool>,
     #[serde(rename = "PortName", default)]
     port_name: Option<String>,
     #[serde(rename = "Type", default)]
@@ -254,7 +254,7 @@ impl From<PowerShellPrinter> for PrinterInfo {
 
         Self {
             name: value.name,
-            is_default: value.default,
+            is_default: value.default.unwrap_or(false),
             dpi,
             port,
             is_local,
@@ -361,5 +361,22 @@ fn command_error(command: &str, message: String) -> PrintError {
     PrintError::CommandFailed {
         command: command.to_string(),
         message,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_printers_json;
+
+    #[test]
+    fn parse_printers_json_accepts_null_default_flag() {
+        let printers = parse_printers_json(
+            r#"[{"Name":"Printer A","Default":null,"PortName":"USB001","Type":"Local","DeviceType":"Print","DriverName":"Driver"}]"#,
+        )
+        .unwrap();
+
+        assert_eq!(printers.len(), 1);
+        assert!(!printers[0].is_default);
+        assert_eq!(printers[0].name, "Printer A");
     }
 }

--- a/crates/runtime/tests/lifecycle_tests.rs
+++ b/crates/runtime/tests/lifecycle_tests.rs
@@ -50,7 +50,7 @@ async fn shutdown_stops_listener_and_workers() {
     .build()
     .unwrap();
     let handle = runtime.start().await.unwrap();
-    let addr = handle.listen_addr();
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], handle.listen_addr().port()));
 
     assert!(tokio::net::TcpStream::connect(addr).await.is_ok());
     handle.shutdown().await.unwrap();

--- a/scripts/prepare-windows-cli.mjs
+++ b/scripts/prepare-windows-cli.mjs
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process';
-import { copyFileSync, mkdirSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { copyFileSync, mkdirSync, renameSync, rmSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -41,22 +42,29 @@ export function sidecarBuildEnvironment(environment = process.env) {
   };
 }
 
-export function prepareWindowsCli(target, repositoryRoot = root) {
+export function prepareWindowsCli(target, repositoryRoot = root, runCargo = spawnSync) {
   validateWindowsTarget(target);
-  const result = spawnSync('cargo', sidecarCargoArgs(target), {
+  const result = runCargo('cargo', sidecarCargoArgs(target), {
     cwd: repositoryRoot,
     env: sidecarBuildEnvironment(),
     stdio: 'inherit',
   });
-  if (result.status !== 0) process.exit(result.status ?? 1);
-
-  const source = resolve(repositoryRoot, 'target', target, 'release', 'print-bridge-desktop-cli.exe');
   const destination = sidecarOutputPath(repositoryRoot, target);
   mkdirSync(dirname(destination), { recursive: true });
-  copyFileSync(source, destination);
+  if (result.status !== 0) return result.status ?? 1;
+
+  const source = resolve(repositoryRoot, 'target', target, 'release', 'print-bridge-desktop-cli.exe');
+  const temporary = `${destination}.${randomUUID()}.tmp`;
+  try {
+    copyFileSync(source, temporary);
+    renameSync(temporary, destination);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
   console.log(`Prepared Windows CLI sidecar: ${destination}`);
+  return 0;
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  prepareWindowsCli(process.argv[2] ?? '');
+  process.exitCode = prepareWindowsCli(process.argv[2] ?? '');
 }

--- a/scripts/prepare-windows-cli.test.mjs
+++ b/scripts/prepare-windows-cli.test.mjs
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { basename, dirname, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
+  prepareWindowsCli,
   sidecarBuildEnvironment,
   sidecarCargoArgs,
   sidecarOutputPath,
@@ -58,4 +60,69 @@ test('desktop CLI binary is gated behind the Windows-only build feature', () => 
     manifest,
     /name = "print-bridge-desktop-cli"[\s\S]*required-features = \["windows-cli"\]/,
   );
+});
+
+function temporaryRepository() {
+  return mkdtempSync(resolve(tmpdir(), 'print-bridge-windows-cli-'));
+}
+
+function sidecarSourcePath(repositoryRoot, target) {
+  return resolve(repositoryRoot, 'target', target, 'release', 'print-bridge-desktop-cli.exe');
+}
+
+test('failed Cargo build preserves an existing sidecar', () => {
+  const repositoryRoot = temporaryRepository();
+  const target = 'x86_64-pc-windows-msvc';
+  const destination = sidecarOutputPath(repositoryRoot, target);
+  mkdirSync(dirname(destination), { recursive: true });
+  writeFileSync(destination, 'working sidecar');
+
+  try {
+    const exitCode = prepareWindowsCli(target, repositoryRoot, () => ({ status: 1 }));
+
+    assert.equal(exitCode, 1);
+    assert.equal(readFileSync(destination, 'utf8'), 'working sidecar');
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('failed sidecar copy preserves an existing sidecar', () => {
+  const repositoryRoot = temporaryRepository();
+  const target = 'x86_64-pc-windows-msvc';
+  const destination = sidecarOutputPath(repositoryRoot, target);
+  mkdirSync(dirname(destination), { recursive: true });
+  writeFileSync(destination, 'working sidecar');
+
+  try {
+    assert.throws(() => prepareWindowsCli(target, repositoryRoot, () => ({ status: 0 })));
+
+    assert.equal(readFileSync(destination, 'utf8'), 'working sidecar');
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('successful build replaces the sidecar and removes its temporary output', () => {
+  const repositoryRoot = temporaryRepository();
+  const target = 'x86_64-pc-windows-msvc';
+  const destination = sidecarOutputPath(repositoryRoot, target);
+  const source = sidecarSourcePath(repositoryRoot, target);
+  mkdirSync(dirname(destination), { recursive: true });
+  mkdirSync(dirname(source), { recursive: true });
+  writeFileSync(destination, 'old sidecar');
+  writeFileSync(source, 'new sidecar');
+
+  try {
+    const exitCode = prepareWindowsCli(target, repositoryRoot, () => ({ status: 0 }));
+
+    assert.equal(exitCode, 0);
+    assert.equal(readFileSync(destination, 'utf8'), 'new sidecar');
+    assert.equal(
+      readdirSync(dirname(destination)).some((entry) => entry.startsWith(`${basename(destination)}.`)),
+      false,
+    );
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
This PR improves Windows desktop support by fixing runtime and integration issues that affected browser rendering, printer discovery, and config persistence.

## Changes
- Prevent HTML rendering from opening visible browser windows on Windows
- Harden Windows printer parsing and config save behavior
- Fix Windows desktop development integration for the Tauri/Vite setup
- Update the Windows CLI preparation and runtime feature flags

## Verification
- `pnpm --dir apps/desktop typecheck`
- `pnpm --dir apps/desktop lint`
- `pnpm --dir apps/desktop test`
- `pnpm --dir apps/desktop build`
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test -p print-bridge-core --lib`
- `cargo test -p print-bridge-cli --lib`
- `node --test scripts/prepare-windows-cli.test.mjs`
- `cargo test -p print-bridge-runtime parse_printers_json_accepts_null_default_flag`

## Notes
The scope is intentionally limited to Windows-specific fixes needed to make desktop development and runtime behavior more reliable.