### PR TITLE
chore: release v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4407,7 +4407,7 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "print-bridge-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4429,7 +4429,7 @@ dependencies = [
 
 [[package]]
 name = "print-bridge-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "base64 0.22.1",
  "ipnet",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "print-bridge-desktop"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "auto-launch",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "print-bridge-runtime"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -4506,7 +4506,7 @@ dependencies = [
 
 [[package]]
 name = "print-bridge-server"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "clap",
  "print-bridge-cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Vergil Lai"]

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "print-bridge",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PrintBridge",
   "mainBinaryName": "print-bridge",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "com.vergil.printbridge",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Bump the PrintBridge workspace and desktop version from 0.2.2 to 0.2.3, refresh Cargo.lock workspace package versions, and prepare the patch release containing the Windows console-window fix from PR #3. Validated with git diff --check and node scripts/release.mjs --dry-run; the full Linux, Windows, and macOS checks run on this PR.